### PR TITLE
Set coinType of relevant chain in L2Registrar

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ Durin uses [foundry](https://github.com/foundry-rs/foundry), to install follow t
 
 ### 4. Prepare .env
 
-
 ```shell
 cp example.env .env
 ```
@@ -84,11 +83,12 @@ bash deploy/deployL2Registrar.sh
 
 ### 6. Connect Registrar to L2Registry
 
-Only the Registrar can call `register` on the Registry. The owner of the registry can add a registrar thus enabling minting. The [configureRegistry.sh](https://github.com/resolverworks/durin/blob/main/deploy/configureRegistry.sh) script adds the Registrar to the Registry by calling the `addRegistrar()`
+Only the Registrar can call `register()` on the Registry. The owner of the registry can add a registrar thus enabling minting. The [configureRegistry.sh](https://github.com/resolverworks/durin/blob/main/deploy/configureRegistry.sh) script adds the Registrar to the Registry by calling the `addRegistrar()`
 
 ```shell
 bash deploy/configureRegistry.sh
 ```
+
 ## Contracts
 
 This repo includes the L2 contracts required to enable subname issuance.
@@ -114,6 +114,5 @@ This repo includes the L2 contracts required to enable subname issuance.
 | Linea Sepolia    | [`0xA59eF1DCc0c4bcbDC718b95c0680b6B97Bb451eb`](https://sepolia.lineascan.build/address/0xA59eF1DCc0c4bcbDC718b95c0680b6B97Bb451eb)       |
 
 ## Architecture
+
 ![architecture](https://github.com/user-attachments/assets/06065784-0516-498e-a512-d7b63892599a)
-
-

--- a/src/L2Registrar.sol
+++ b/src/L2Registrar.sol
@@ -14,66 +14,66 @@ pragma solidity 0.8.20;
 
 import {IL2Registry} from "./IL2Registry.sol";
 
-/// @notice Thrown when attempting to interact with a non-existent token
-error ERC721NonexistentToken(uint256 tokenId);
-
 /// @title Registrar (for Layer 2)
 /// @dev This is a simple registrar contract that is mean to be modified.
 contract L2Registrar {
     /// @notice Emitted when a new name is registered
-    /// @param label The registered name
+    /// @param label The registered label (e.g. "name" in "name.eth")
     /// @param owner The owner of the newly registered name
     event NameRegistered(string indexed label, address indexed owner);
 
     /// @notice Reference to the target registry contract
-    /// @dev Immutable to save gas and prevent manipulation
-    IL2Registry public immutable targetRegistry;
+    IL2Registry public immutable registry;
+
+    /// @notice The chainId for the current chain
+    uint256 public chainId;
+
+    /// @notice The coinType for the current chain (ENSIP-11)
+    uint256 public immutable coinType;
 
     /// @notice Initializes the registrar with a registry contract
     /// @param _registry Address of the L2Registry contract
     constructor(IL2Registry _registry) {
-        targetRegistry = _registry;
+        assembly {
+            sstore(chainId.slot, chainid())
+        }
+
+        coinType = (0x80000000 | chainId) >> 0;
+        registry = _registry;
     }
 
-    /// @notice Checks if a given tokenId is available for registration
-    /// @param tokenId The tokenId to check availability for
-    /// @return available True if the tokenId can be registered, false if already taken
+    /// @notice Checks if a given label is available for registration
+    /// @param label The label to check availability for
+    /// @return available True if the label can be registered, false if already taken
     /// @dev Uses try-catch to handle the ERC721NonexistentToken error
-    function available(uint256 tokenId) external view returns (bool) {
-        try targetRegistry.ownerOf(tokenId) returns (address) {
-            // Token exists and has an owner
+    function available(string memory label) external view returns (bool) {
+        bytes32 labelhash = keccak256(bytes(label));
+        uint256 tokenId = uint256(labelhash);
+
+        try registry.ownerOf(tokenId) {
             return false;
-        } catch (bytes memory reason) {
-            // Check if the error is specifically ERC721NonexistentToken
-            if (
-                keccak256(reason) ==
-                keccak256(
-                    abi.encodeWithSelector(
-                        ERC721NonexistentToken.selector,
-                        tokenId
-                    )
-                )
-            ) {
-                // Token doesn't exist, so it's available
-                return true;
-            } else {
-                // Propagate any other errors
-                revert(string(reason));
-            }
+        } catch {
+            return true;
         }
     }
 
     /// @notice Registers a new name
-    /// @param label The name to register
+    /// @param label The label to register (e.g. "name" for "name.eth")
     /// @param owner The address that will own the name
     function register(string memory label, address owner) external {
-        targetRegistry.register(label, owner);
-        // Set the mainnet resolved address
-        targetRegistry.setAddr(
-            keccak256(bytes(label)), // Convert label to bytes32 hash
-            60, // Mainnet coinType
-            abi.encodePacked(owner) // Convert address to bytes
-        );
+        bytes32 labelhash = keccak256(bytes(label)); // Hash the label
+        bytes memory addr = abi.encodePacked(owner); // Convert address to bytes
+
+        // Set the forward address for the current chain. This is needed for reverse resolution.
+        // E.g. if this contract is deployed to Base, set an address for chainId 8453 which is
+        // coinType 2147492101 according to ENSIP-11.
+        registry.setAddr(labelhash, coinType, addr);
+
+        // Set the forward address for mainnet ETH (coinType 60) for easier debugging.
+        registry.setAddr(labelhash, 60, addr);
+
+        // Register the name in the L2 registry
+        registry.register(label, owner);
         emit NameRegistered(label, owner);
     }
 }

--- a/test/L2RegistrarTest.t.sol
+++ b/test/L2RegistrarTest.t.sol
@@ -22,9 +22,7 @@ contract L2RegistrarTest is Test {
         factory = new L2RegistryFactory(salt);
 
         // Deploy a registry through the factory
-        registry = L2Registry(
-            factory.deployRegistry("TestNames", "TEST", "https://test.uri/")
-        );
+        registry = L2Registry(factory.deployRegistry("TestNames", "TEST", "https://test.uri/"));
 
         // Deploy and set up registrar
         registrar = new L2Registrar(IL2Registry(address(registry)));
@@ -37,7 +35,7 @@ contract L2RegistrarTest is Test {
         bytes32 labelhash = keccak256(abi.encodePacked(label));
 
         // Should be available before registration
-        assertTrue(registrar.available(uint256(labelhash)));
+        assertTrue(registrar.available(label));
 
         // Register the name
         vm.deal(user1, 1 ether);
@@ -45,7 +43,7 @@ contract L2RegistrarTest is Test {
         registrar.register(label, user1);
 
         // Should not be available after registration
-        assertFalse(registrar.available(uint256(labelhash)));
+        assertFalse(registrar.available(label));
     }
 
     function testFuzz_Register(string calldata label) public {
@@ -70,14 +68,10 @@ contract L2RegistrarTest is Test {
         vm.startPrank(admin);
 
         // Deploy second registry
-        L2Registry registry2 = L2Registry(
-            factory.deployRegistry("TestNames2", "TEST2", "https://test2.uri/")
-        );
+        L2Registry registry2 = L2Registry(factory.deployRegistry("TestNames2", "TEST2", "https://test2.uri/"));
 
         // Verify both registries work independently
-        L2Registrar registrar2 = new L2Registrar(
-            IL2Registry(address(registry2))
-        );
+        L2Registrar registrar2 = new L2Registrar(IL2Registry(address(registry2)));
         registry2.addRegistrar(address(registrar2));
 
         // Register name in first registry
@@ -101,25 +95,14 @@ contract L2RegistrarTest is Test {
 
     function test_RegistryInitialization() public {
         vm.prank(admin);
-        L2Registry newRegistry = L2Registry(
-            factory.deployRegistry("TestNames3", "TEST3", "https://test3.uri/")
-        );
+        L2Registry newRegistry = L2Registry(factory.deployRegistry("TestNames3", "TEST3", "https://test3.uri/"));
 
         // Verify initialization worked
-        assertTrue(
-            newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), admin)
-        );
+        assertTrue(newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), admin));
         assertTrue(newRegistry.hasRole(newRegistry.ADMIN_ROLE(), admin));
 
         // Verify factory doesn't retain any roles
-        assertFalse(
-            newRegistry.hasRole(
-                newRegistry.DEFAULT_ADMIN_ROLE(),
-                address(factory)
-            )
-        );
-        assertFalse(
-            newRegistry.hasRole(newRegistry.ADMIN_ROLE(), address(factory))
-        );
+        assertFalse(newRegistry.hasRole(newRegistry.DEFAULT_ADMIN_ROLE(), address(factory)));
+        assertFalse(newRegistry.hasRole(newRegistry.ADMIN_ROLE(), address(factory)));
     }
 }


### PR DESCRIPTION
- Simplify `available()` to accept a string and return clean boolean
- Set relevant coinType automatically from L2Registrar to make L2 primary names easier